### PR TITLE
Using pynput instead of pyautogui

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,10 +28,10 @@ numpy==1.24.3
 openai==0.27.7
 openai-whisper==20230314
 Pillow==9.5.0
-PyAutoGUI==0.9.54
 pycparser==2.21
 PyGetWindow==0.0.9
 PyMsgBox==1.0.9
+pynput==1.7.6
 pyperclip==1.8.2
 PyRect==0.2.0
 pyscreenshot==3.1

--- a/src/main.py
+++ b/src/main.py
@@ -2,8 +2,9 @@ import json
 import os
 import queue
 import threading
+import time
 import keyboard
-import pyautogui
+from pynput.keyboard import Controller
 from transcription import record_and_transcribe
 from status_window import StatusWindow
 
@@ -15,7 +16,7 @@ class ResultThread(threading.Thread):
 
     def run(self):
         self.result = self._target(*self._args, cancel_flag=lambda: self.stop_transcription, **self._kwargs)
-        
+
     def stop(self):
         self.stop_transcription = True
 
@@ -73,7 +74,7 @@ def on_shortcut():
     status_window.recording_thread = recording_thread
     status_window.start()
     recording_thread.start()
-    
+
     recording_thread.join()
 
     if status_window.is_alive():
@@ -82,11 +83,16 @@ def on_shortcut():
     transcribed_text = recording_thread.result
 
     if transcribed_text:
-        pyautogui.write(transcribed_text, interval=config['writing_key_press_delay'])
+        typewrite(transcribed_text, interval=config['writing_key_press_delay'])
 
 def format_keystrokes(key_string):
     return '+'.join(word.capitalize() for word in key_string.split('+'))
 
+def typewrite(text, interval):
+    for letter in text:
+        pyinput_keyboard.press(letter)
+        pyinput_keyboard.release(letter)
+        time.sleep(interval)
 
 
 # Main script
@@ -96,6 +102,7 @@ method = 'OpenAI\'s API' if config['use_api'] else 'a local model'
 status_queue = queue.Queue()
 
 keyboard.add_hotkey(config['activation_key'], on_shortcut)
+pyinput_keyboard = Controller()
 
 print(f'Script activated. Whisper is set to run using {method}. To change this, modify the "use_api" value in the src\\config.json file.')
 print(f'Press {format_keystrokes(config["activation_key"])} to start recording and transcribing. Press Ctrl+C on the terminal window to quit.')
@@ -104,4 +111,3 @@ try:
 except KeyboardInterrupt:
     print('\nExiting the script...')
     os.system('exit')
-


### PR DESCRIPTION
Hi,
Nice project!

I have a custom keyboard layout and `PyAutoGUI` can't handle some non-English keyboards (mine is not even a standard one) check here https://github.com/asweigart/pyautogui/issues/137.
I did try some alternatives (like using `keyboard` that is already imported) but I settled with `pynput`.
Because you were using some delay between keys I created a helper function but if for some reason it won't be needed it can be as simple as:
`pyinput_keyboard.type(transcribed_text)`

I also had trouble with the sample rate (Linux Pipewire) but I solved it for another PR (maybe).

Thanks!