### PR TITLE
Fix: Graceful Degradation to CPU if CUDA isn't available

### DIFF
--- a/src/transcription.py
+++ b/src/transcription.py
@@ -9,6 +9,7 @@ import webrtcvad
 from dotenv import load_dotenv
 from faster_whisper import WhisperModel
 import keyboard
+import torch
 
 if load_dotenv():
     openai.api_key = os.getenv('OPENAI_API_KEY')
@@ -25,9 +26,19 @@ def process_transcription(transcription, config=None):
     return transcription
 
 def create_local_model(config):
-    model = WhisperModel(config['local_model_options']['model'],
-                         device=config['local_model_options']['device'],
-                         compute_type=config['local_model_options']['compute_type'],)
+    if torch.cuda.is_available() and config['local_model_options']['device'] != 'cpu':
+        try:
+            model = WhisperModel(config['local_model_options']['model'],
+                                 device=config['local_model_options']['device'],
+                                 compute_type=config['local_model_options']['compute_type'])
+        except Exception as e:
+            print(f"Error initializing WhisperModel with CUDA: {e}")
+            print("Falling back to CPU.")
+            model = WhisperModel(config['local_model_options']['model'], device='cpu')
+    else:
+        print("CUDA not available, using CPU.")
+        model = WhisperModel(config['local_model_options']['model'], device='cpu')
+    
     return model
 
 """

--- a/src/transcription.py
+++ b/src/transcription.py
@@ -34,10 +34,14 @@ def create_local_model(config):
         except Exception as e:
             print(f"Error initializing WhisperModel with CUDA: {e}")
             print("Falling back to CPU.")
-            model = WhisperModel(config['local_model_options']['model'], device='cpu')
+            model = WhisperModel(config['local_model_options']['model'], 
+                                 device='cpu',
+                                 compute_type=config['local_model_options']['compute_type'])
     else:
         print("CUDA not available, using CPU.")
-        model = WhisperModel(config['local_model_options']['model'], device='cpu')
+        model = WhisperModel(config['local_model_options']['model'], 
+                             device='cpu',
+                             compute_type=config['local_model_options']['compute_type'])
     
     return model
 


### PR DESCRIPTION
**Issue**

https://github.com/savbell/whisper-writer/issues/29

**Solution**

Include a check using torch if CUDA is available. If it's not, gracefully degrade to cpu.

**Testing**

Config json set to `auto`. But the torch cuda check fails, and the model gracefully degrades to cpu:

![image](https://github.com/savbell/whisper-writer/assets/63753020/7eee4473-4bd7-4b21-93da-0de8e1627846)
