### PR TITLE
Added compatible `large-v3-turbo` model

### DIFF
--- a/src/config_schema.yaml
+++ b/src/config_schema.yaml
@@ -54,6 +54,7 @@ model_options:
         - large-v1
         - large-v2
         - large-v3
+        - deepdml/faster-whisper-large-v3-turbo-ct2
     device:
       value: auto
       type: str


### PR DESCRIPTION
As [OpenAI write](https://github.com/openai/whisper/blob/main/model-card.md#model-details), they released a new `large-v3-turbo` model in September 2024. A [`faster-whisper` issue](https://github.com/SYSTRAN/faster-whisper/issues/1025#issuecomment-2405193681) references a Hugging Face model usable with it. This PR adds the option to choose this model. According to [benchmarks](https://github.com/SYSTRAN/faster-whisper/issues/1030) and my test, it seems worth adding. According to the docs of `faster-whisper`'s [`download_model()`](https://github.com/SYSTRAN/faster-whisper/blob/master/faster_whisper/utils.py#L58) function, you have to use the Hugging Face "username/repository" format to utilize the model.

EDIT: See also <https://github.com/openai/whisper/discussions/2363> (e.g., bottom two diagrams in initial post).