### PR TITLE
Fix Windows keyboard issues with non-Latin layouts: hotkey detection, text insertion, phantom characters

### DIFF
--- a/src/config_schema.yaml
+++ b/src/config_schema.yaml
@@ -145,9 +145,10 @@ post_processing:
   input_method:
     value: pynput
     type: str
-    description: "The method to use for simulating keyboard input."
+    description: "The method to use for inserting transcribed text. 'clipboard' pastes via Ctrl+V (Windows only, instant, works with any keyboard layout). 'pynput' types character by character (may have issues with non-Latin layouts on Windows)."
     options:
       - pynput
+      - clipboard
       - ydotool
       - dotool
 

--- a/src/input_simulation.py
+++ b/src/input_simulation.py
@@ -150,7 +150,8 @@ class InputSimulator:
         import sys
         if sys.platform != 'win32':
             print("Warning: 'clipboard' input method is Windows only. Falling back to pynput.")
-            return self._typewrite_pynput(text, 0.005)
+            interval = ConfigManager.get_config_value('post_processing', 'writing_key_press_delay')
+            return self._typewrite_pynput(text, interval)
 
         import ctypes
         user32 = ctypes.windll.user32

--- a/src/input_simulation.py
+++ b/src/input_simulation.py
@@ -2,7 +2,7 @@ import subprocess
 import os
 import signal
 import time
-from pynput.keyboard import Controller as PynputController
+from pynput.keyboard import Controller as PynputController, Key as PynputKey
 
 from utils import ConfigManager
 
@@ -31,7 +31,7 @@ class InputSimulator:
         self.input_method = ConfigManager.get_config_value('post_processing', 'input_method')
         self.dotool_process = None
 
-        if self.input_method == 'pynput':
+        if self.input_method in ('pynput', 'clipboard'):
             self.keyboard = PynputController()
         elif self.input_method == 'dotool':
             self._initialize_dotool()
@@ -59,12 +59,115 @@ class InputSimulator:
             text (str): The text to type.
         """
         interval = ConfigManager.get_config_value('post_processing', 'writing_key_press_delay')
-        if self.input_method == 'pynput':
+        if self.input_method == 'clipboard':
+            self._typewrite_clipboard(text)
+        elif self.input_method == 'pynput':
             self._typewrite_pynput(text, interval)
         elif self.input_method == 'ydotool':
             self._typewrite_ydotool(text, interval)
         elif self.input_method == 'dotool':
             self._typewrite_dotool(text, interval)
+
+    @staticmethod
+    def _setup_win32_clipboard():
+        """Configure ctypes function signatures for Win32 clipboard API."""
+        import ctypes
+
+        user32 = ctypes.windll.user32
+        kernel32 = ctypes.windll.kernel32
+
+        kernel32.GlobalAlloc.argtypes = [ctypes.c_uint, ctypes.c_size_t]
+        kernel32.GlobalAlloc.restype = ctypes.c_void_p
+        kernel32.GlobalLock.argtypes = [ctypes.c_void_p]
+        kernel32.GlobalLock.restype = ctypes.c_void_p
+        kernel32.GlobalUnlock.argtypes = [ctypes.c_void_p]
+        kernel32.GlobalFree.argtypes = [ctypes.c_void_p]
+        user32.GetClipboardData.restype = ctypes.c_void_p
+        user32.SetClipboardData.argtypes = [ctypes.c_uint, ctypes.c_void_p]
+        user32.SetClipboardData.restype = ctypes.c_void_p
+
+        return user32, kernel32
+
+    @staticmethod
+    def _win32_set_clipboard(text):
+        """Set clipboard content using Windows API."""
+        import ctypes
+
+        user32, kernel32 = InputSimulator._setup_win32_clipboard()
+
+        CF_UNICODETEXT = 13
+        GMEM_MOVEABLE = 0x0002
+
+        encoded = text.encode('utf-16-le') + b'\x00\x00'
+        h = kernel32.GlobalAlloc(GMEM_MOVEABLE, len(encoded))
+        ptr = kernel32.GlobalLock(h)
+        ctypes.memmove(ptr, encoded, len(encoded))
+        kernel32.GlobalUnlock(h)
+
+        if user32.OpenClipboard(0):
+            user32.EmptyClipboard()
+            user32.SetClipboardData(CF_UNICODETEXT, h)
+            user32.CloseClipboard()
+        else:
+            kernel32.GlobalFree(h)
+
+    @staticmethod
+    def _win32_get_clipboard():
+        """Get clipboard text content using Windows API. Returns None on failure."""
+        import ctypes
+
+        user32, kernel32 = InputSimulator._setup_win32_clipboard()
+
+        CF_UNICODETEXT = 13
+        result = None
+
+        if user32.OpenClipboard(0):
+            handle = user32.GetClipboardData(CF_UNICODETEXT)
+            if handle:
+                ptr = kernel32.GlobalLock(handle)
+                if ptr:
+                    result = ctypes.wstring_at(ptr)
+                    kernel32.GlobalUnlock(handle)
+            user32.CloseClipboard()
+        return result
+
+    def _typewrite_clipboard(self, text):
+        """
+        Insert text by pasting from the clipboard (Ctrl+V).
+        Uses Windows API directly via ctypes — no external dependencies,
+        works with any keyboard layout, and handles Unicode correctly.
+        Windows only. Falls back to pynput on other platforms.
+        """
+        import sys
+        if sys.platform != 'win32':
+            print("Warning: 'clipboard' input method is Windows only. Falling back to pynput.")
+            return self._typewrite_pynput(text, 0.005)
+
+        import ctypes
+
+        VK_CONTROL = 0x11
+        VK_V = 0x56
+        KEYEVENTF_KEYUP = 0x0002
+        user32 = ctypes.windll.user32
+
+        old_clipboard = self._win32_get_clipboard()
+
+        try:
+            self._win32_set_clipboard(text)
+            time.sleep(0.05)
+
+            user32.keybd_event(VK_CONTROL, 0, 0, 0)
+            user32.keybd_event(VK_V, 0, 0, 0)
+            user32.keybd_event(VK_V, 0, KEYEVENTF_KEYUP, 0)
+            user32.keybd_event(VK_CONTROL, 0, KEYEVENTF_KEYUP, 0)
+
+            time.sleep(0.2)
+        finally:
+            if old_clipboard is not None:
+                try:
+                    self._win32_set_clipboard(old_clipboard)
+                except Exception:
+                    pass
 
     def _typewrite_pynput(self, text, interval):
         """

--- a/src/input_simulation.py
+++ b/src/input_simulation.py
@@ -2,7 +2,7 @@ import subprocess
 import os
 import signal
 import time
-from pynput.keyboard import Controller as PynputController, Key as PynputKey
+from pynput.keyboard import Controller as PynputController
 
 from utils import ConfigManager
 
@@ -31,8 +31,10 @@ class InputSimulator:
         self.input_method = ConfigManager.get_config_value('post_processing', 'input_method')
         self.dotool_process = None
 
-        if self.input_method in ('pynput', 'clipboard'):
+        if self.input_method == 'pynput':
             self.keyboard = PynputController()
+        elif self.input_method == 'clipboard':
+            self._win32_api_configured = False
         elif self.input_method == 'dotool':
             self._initialize_dotool()
 
@@ -68,14 +70,13 @@ class InputSimulator:
         elif self.input_method == 'dotool':
             self._typewrite_dotool(text, interval)
 
-    @staticmethod
-    def _setup_win32_clipboard():
-        """Configure ctypes function signatures for Win32 clipboard API."""
+    def _ensure_win32_api(self):
+        """Configure ctypes function signatures for Win32 clipboard API (once)."""
+        if self._win32_api_configured:
+            return
         import ctypes
-
-        user32 = ctypes.windll.user32
         kernel32 = ctypes.windll.kernel32
-
+        user32 = ctypes.windll.user32
         kernel32.GlobalAlloc.argtypes = [ctypes.c_uint, ctypes.c_size_t]
         kernel32.GlobalAlloc.restype = ctypes.c_void_p
         kernel32.GlobalLock.argtypes = [ctypes.c_void_p]
@@ -85,22 +86,26 @@ class InputSimulator:
         user32.GetClipboardData.restype = ctypes.c_void_p
         user32.SetClipboardData.argtypes = [ctypes.c_uint, ctypes.c_void_p]
         user32.SetClipboardData.restype = ctypes.c_void_p
+        self._win32_api_configured = True
 
-        return user32, kernel32
-
-    @staticmethod
-    def _win32_set_clipboard(text):
+    def _win32_set_clipboard(self, text):
         """Set clipboard content using Windows API."""
         import ctypes
-
-        user32, kernel32 = InputSimulator._setup_win32_clipboard()
+        self._ensure_win32_api()
+        kernel32 = ctypes.windll.kernel32
+        user32 = ctypes.windll.user32
 
         CF_UNICODETEXT = 13
         GMEM_MOVEABLE = 0x0002
 
         encoded = text.encode('utf-16-le') + b'\x00\x00'
         h = kernel32.GlobalAlloc(GMEM_MOVEABLE, len(encoded))
+        if not h:
+            return
         ptr = kernel32.GlobalLock(h)
+        if not ptr:
+            kernel32.GlobalFree(h)
+            return
         ctypes.memmove(ptr, encoded, len(encoded))
         kernel32.GlobalUnlock(h)
 
@@ -111,12 +116,12 @@ class InputSimulator:
         else:
             kernel32.GlobalFree(h)
 
-    @staticmethod
-    def _win32_get_clipboard():
+    def _win32_get_clipboard(self):
         """Get clipboard text content using Windows API. Returns None on failure."""
         import ctypes
-
-        user32, kernel32 = InputSimulator._setup_win32_clipboard()
+        self._ensure_win32_api()
+        kernel32 = ctypes.windll.kernel32
+        user32 = ctypes.windll.user32
 
         CF_UNICODETEXT = 13
         result = None
@@ -131,6 +136,10 @@ class InputSimulator:
             user32.CloseClipboard()
         return result
 
+    # Delay (in seconds) to wait for the paste operation to complete
+    # before restoring the original clipboard content.
+    _PASTE_SETTLE_DELAY = 0.2
+
     def _typewrite_clipboard(self, text):
         """
         Insert text by pasting from the clipboard (Ctrl+V).
@@ -144,11 +153,11 @@ class InputSimulator:
             return self._typewrite_pynput(text, 0.005)
 
         import ctypes
+        user32 = ctypes.windll.user32
 
         VK_CONTROL = 0x11
         VK_V = 0x56
         KEYEVENTF_KEYUP = 0x0002
-        user32 = ctypes.windll.user32
 
         old_clipboard = self._win32_get_clipboard()
 
@@ -161,7 +170,7 @@ class InputSimulator:
             user32.keybd_event(VK_V, 0, KEYEVENTF_KEYUP, 0)
             user32.keybd_event(VK_CONTROL, 0, KEYEVENTF_KEYUP, 0)
 
-            time.sleep(0.2)
+            time.sleep(self._PASTE_SETTLE_DELAY)
         finally:
             if old_clipboard is not None:
                 try:

--- a/src/key_listener.py
+++ b/src/key_listener.py
@@ -322,6 +322,7 @@ class KeyListener:
             raise RuntimeError("No supported input backend found")
         self.active_backend = self.backends[0]
         self.active_backend.on_input_event = self.on_input_event
+        self._sync_chord_to_backend()
 
     def set_active_backend(self, backend_class):
         """Set a specific backend as active."""
@@ -331,9 +332,15 @@ class KeyListener:
                 self.stop()
             self.active_backend = new_backend
             self.active_backend.on_input_event = self.on_input_event
+            self._sync_chord_to_backend()
             self.start()
         else:
             raise ValueError(f"Backend {backend_class.__name__} is not available")
+
+    def _sync_chord_to_backend(self):
+        """Pass the current KeyChord to the active backend for event suppression."""
+        if self.active_backend and hasattr(self.active_backend, '_key_chord'):
+            self.active_backend._key_chord = self.key_chord
 
     def update_backend(self):
         """Update the active backend based on current configuration."""
@@ -411,6 +418,7 @@ class KeyListener:
     def update_activation_keys(self):
         """Update activation keys from the current configuration."""
         self.load_activation_keys()
+        self._sync_chord_to_backend()
 
 class EvdevBackend(InputBackend):
     """
@@ -760,19 +768,33 @@ class PynputBackend(InputBackend):
         self.keyboard = None
         self.mouse = None
         self.key_map = None
+        self._key_chord = None
+        self._pressed_vks = set()
 
     def start(self):
         """Start listening for keyboard and mouse events."""
+        import sys
+
         if self.keyboard is None or self.mouse is None:
             from pynput import keyboard, mouse
             self.keyboard = keyboard
             self.mouse = mouse
             self.key_map = self._create_key_map()
+            self._vk_map = self._build_vk_map()
 
-        self.keyboard_listener = self.keyboard.Listener(
-            on_press=self._on_keyboard_press,
-            on_release=self._on_keyboard_release
-        )
+        self._last_vk = None
+
+        listener_kwargs = {
+            'on_press': self._on_keyboard_press,
+            'on_release': self._on_keyboard_release,
+        }
+        # On Windows, use event_filter to capture raw virtual key codes
+        # before pynput translates them (pynput loses vk when it converts to char)
+        # and to suppress activation-combo keys from reaching other applications.
+        if sys.platform == 'win32':
+            listener_kwargs['win32_event_filter'] = self._win32_event_filter
+
+        self.keyboard_listener = self.keyboard.Listener(**listener_kwargs)
         self.mouse_listener = self.mouse.Listener(
             on_click=self._on_mouse_click
         )
@@ -788,27 +810,118 @@ class PynputBackend(InputBackend):
             self.mouse_listener.stop()
             self.mouse_listener = None
 
-    def _translate_key_event(self, native_event) -> tuple[KeyCode, InputEvent]:
+    def _win32_event_filter(self, msg, data):
+        """Intercept raw Win32 keyboard events to capture the virtual key code
+        and suppress activation-combo keys from reaching other applications.
+
+        Returning False suppresses the event from BOTH the OS and pynput callbacks,
+        so we must manually call on_input_event when suppressing.
+        """
+        vk = data.vkCode
+        self._last_vk = vk
+
+        WM_KEYDOWN = 0x0100
+        WM_SYSKEYDOWN = 0x0104
+        WM_KEYUP = 0x0101
+        WM_SYSKEYUP = 0x0105
+
+        # Track currently pressed virtual key codes
+        is_down = msg in (WM_KEYDOWN, WM_SYSKEYDOWN)
+        is_up = msg in (WM_KEYUP, WM_SYSKEYUP)
+
+        if is_down:
+            self._pressed_vks.add(vk)
+        elif is_up:
+            self._pressed_vks.discard(vk)
+
+        # Suppress non-modifier keys that complete the activation combo
+        if (is_down
+                and self._key_chord is not None
+                and self._vk_map is not None):
+            MODIFIER_VKS = {
+                0xA0, 0xA1,  # Shift L/R
+                0xA2, 0xA3,  # Ctrl L/R
+                0xA4, 0xA5,  # Alt L/R
+                0x5B, 0x5C,  # Win L/R
+            }
+            if vk not in MODIFIER_VKS:
+                test_pressed = set()
+                for pressed_vk in self._pressed_vks:
+                    kc = self._vk_map.get(pressed_vk)
+                    if kc:
+                        test_pressed.add(kc)
+
+                would_activate = bool(test_pressed)
+                for chord_key in self._key_chord.keys:
+                    if isinstance(chord_key, frozenset):
+                        if not any(k in test_pressed for k in chord_key):
+                            would_activate = False
+                            break
+                    elif chord_key not in test_pressed:
+                        would_activate = False
+                        break
+
+                if would_activate:
+                    # Manually fire on_input_event before suppressing,
+                    # because SuppressException prevents pynput callbacks
+                    key_code = self._vk_map.get(vk)
+                    if key_code:
+                        self.on_input_event((key_code, InputEvent.KEY_PRESS))
+                    # Raise SuppressException to suppress from OS
+                    # (pynput treats this as a handled exception — listener keeps running)
+                    from pynput._util.win32 import SystemHook
+                    raise SystemHook.SuppressException()
+
+        # Handle key-up for keys that are part of the activation chord
+        if (is_up
+                and self._key_chord is not None
+                and self._vk_map is not None):
+            key_code = self._vk_map.get(vk)
+            if key_code and key_code in self._key_chord.pressed_keys:
+                self.on_input_event((key_code, InputEvent.KEY_RELEASE))
+
+        return True
+
+    def _translate_key_event(self, native_event) -> tuple[KeyCode | None, InputEvent | None]:
         """Translate a pynput event to our internal event representation."""
         pynput_key, is_press = native_event
-        key_code = self.key_map.get(pynput_key, KeyCode.SPACE)
+
+        # Direct lookup first
+        key_code = self.key_map.get(pynput_key)
+
+        # Fallback 1: use the raw vk captured by win32_event_filter
+        if key_code is None and self._last_vk is not None:
+            key_code = self._vk_map.get(self._last_vk)
+
+        # Fallback 2: use pynput_key.vk if available
+        if key_code is None:
+            vk = getattr(pynput_key, 'vk', None)
+            if vk is not None:
+                key_code = self._vk_map.get(vk)
+
+        if key_code is None:
+            return None, None
+
         event_type = InputEvent.KEY_PRESS if is_press else InputEvent.KEY_RELEASE
         return key_code, event_type
 
     def _on_keyboard_press(self, key):
         """Handle keyboard press events."""
-        translated_event = self._translate_key_event((key, True))
-        self.on_input_event(translated_event)
+        key_code, event_type = self._translate_key_event((key, True))
+        if key_code is not None:
+            self.on_input_event((key_code, event_type))
 
     def _on_keyboard_release(self, key):
         """Handle keyboard release events."""
-        translated_event = self._translate_key_event((key, False))
-        self.on_input_event(translated_event)
+        key_code, event_type = self._translate_key_event((key, False))
+        if key_code is not None:
+            self.on_input_event((key_code, event_type))
 
     def _on_mouse_click(self, x, y, button, pressed):
         """Handle mouse click events."""
-        translated_event = self._translate_key_event((button, pressed))
-        self.on_input_event(translated_event)
+        key_code, event_type = self._translate_key_event((button, pressed))
+        if key_code is not None:
+            self.on_input_event((key_code, event_type))
 
     def _create_key_map(self):
         """Create a mapping from pynput keys to our internal KeyCode enum."""
@@ -953,6 +1066,80 @@ class PynputBackend(InputBackend):
             self.mouse.Button.right: KeyCode.MOUSE_RIGHT,
             self.mouse.Button.middle: KeyCode.MOUSE_MIDDLE,
         }
+
+    def _build_vk_map(self):
+        """Build a virtual key code lookup map for fallback matching.
+
+        When modifier keys (Alt, Ctrl) are held, pynput reports pressed keys
+        via vk (virtual key code) rather than char.  Since from_char() keys
+        have vk=None, we must explicitly map Windows VK codes here.
+        """
+        vk_map = {}
+
+        # First, grab any entries from key_map that already have a vk
+        for pynput_key, key_code in self.key_map.items():
+            vk = getattr(pynput_key, 'vk', None)
+            if vk is not None:
+                vk_map[vk] = key_code
+
+        # Letters: VK_A (0x41) through VK_Z (0x5A)
+        letter_keys = [
+            KeyCode.A, KeyCode.B, KeyCode.C, KeyCode.D, KeyCode.E, KeyCode.F,
+            KeyCode.G, KeyCode.H, KeyCode.I, KeyCode.J, KeyCode.K, KeyCode.L,
+            KeyCode.M, KeyCode.N, KeyCode.O, KeyCode.P, KeyCode.Q, KeyCode.R,
+            KeyCode.S, KeyCode.T, KeyCode.U, KeyCode.V, KeyCode.W, KeyCode.X,
+            KeyCode.Y, KeyCode.Z,
+        ]
+        for i, kc in enumerate(letter_keys):
+            vk_map[0x41 + i] = kc
+
+        # Digits: VK_0 (0x30) through VK_9 (0x39)
+        digit_keys = [
+            KeyCode.ZERO, KeyCode.ONE, KeyCode.TWO, KeyCode.THREE, KeyCode.FOUR,
+            KeyCode.FIVE, KeyCode.SIX, KeyCode.SEVEN, KeyCode.EIGHT, KeyCode.NINE,
+        ]
+        for i, kc in enumerate(digit_keys):
+            vk_map[0x30 + i] = kc
+
+        # Function keys: VK_F1 (0x70) through VK_F24 (0x87)
+        f_keys = [
+            KeyCode.F1, KeyCode.F2, KeyCode.F3, KeyCode.F4, KeyCode.F5, KeyCode.F6,
+            KeyCode.F7, KeyCode.F8, KeyCode.F9, KeyCode.F10, KeyCode.F11, KeyCode.F12,
+            KeyCode.F13, KeyCode.F14, KeyCode.F15, KeyCode.F16, KeyCode.F17, KeyCode.F18,
+            KeyCode.F19, KeyCode.F20, KeyCode.F21, KeyCode.F22, KeyCode.F23, KeyCode.F24,
+        ]
+        for i, kc in enumerate(f_keys):
+            vk_map[0x70 + i] = kc
+
+        # Modifier keys
+        vk_map[0xA0] = KeyCode.SHIFT_LEFT    # VK_LSHIFT
+        vk_map[0xA1] = KeyCode.SHIFT_RIGHT   # VK_RSHIFT
+        vk_map[0xA2] = KeyCode.CTRL_LEFT     # VK_LCONTROL
+        vk_map[0xA3] = KeyCode.CTRL_RIGHT    # VK_RCONTROL
+        vk_map[0xA4] = KeyCode.ALT_LEFT      # VK_LMENU
+        vk_map[0xA5] = KeyCode.ALT_RIGHT     # VK_RMENU
+        vk_map[0x5B] = KeyCode.META_LEFT     # VK_LWIN
+        vk_map[0x5C] = KeyCode.META_RIGHT    # VK_RWIN
+
+        # Special character keys (Windows OEM VK codes)
+        vk_map[0x20] = KeyCode.SPACE       # VK_SPACE
+        vk_map[0x0D] = KeyCode.ENTER       # VK_RETURN
+        vk_map[0x09] = KeyCode.TAB         # VK_TAB
+        vk_map[0x08] = KeyCode.BACKSPACE   # VK_BACK
+        vk_map[0x1B] = KeyCode.ESC         # VK_ESCAPE
+        vk_map[0xBC] = KeyCode.COMMA       # VK_OEM_COMMA
+        vk_map[0xBE] = KeyCode.PERIOD      # VK_OEM_PERIOD
+        vk_map[0xBD] = KeyCode.MINUS       # VK_OEM_MINUS
+        vk_map[0xBB] = KeyCode.EQUALS      # VK_OEM_PLUS (= key)
+        vk_map[0xBA] = KeyCode.SEMICOLON   # VK_OEM_1
+        vk_map[0xBF] = KeyCode.SLASH       # VK_OEM_2
+        vk_map[0xC0] = KeyCode.BACKQUOTE   # VK_OEM_3
+        vk_map[0xDB] = KeyCode.LEFT_BRACKET  # VK_OEM_4
+        vk_map[0xDC] = KeyCode.BACKSLASH   # VK_OEM_5
+        vk_map[0xDD] = KeyCode.RIGHT_BRACKET  # VK_OEM_6
+        vk_map[0xDE] = KeyCode.QUOTE       # VK_OEM_7
+
+        return vk_map
 
     def on_input_event(self, event):
         """

--- a/src/key_listener.py
+++ b/src/key_listener.py
@@ -263,11 +263,15 @@ class KeyChord:
 
     def is_active(self) -> bool:
         """Check if all keys in the chord are currently pressed."""
+        return self.would_activate(self.pressed_keys)
+
+    def would_activate(self, pressed: Set[KeyCode]) -> bool:
+        """Check if a given set of pressed keys would satisfy this chord."""
         for key in self.keys:
             if isinstance(key, frozenset):
-                if not any(k in self.pressed_keys for k in key):
+                if not any(k in pressed for k in key):
                     return False
-            elif key not in self.pressed_keys:
+            elif key not in pressed:
                 return False
         return True
 
@@ -783,14 +787,15 @@ class PynputBackend(InputBackend):
             self._vk_map = self._build_vk_map()
 
         self._last_vk = None
+        self._pressed_vks.clear()
 
         listener_kwargs = {
             'on_press': self._on_keyboard_press,
             'on_release': self._on_keyboard_release,
         }
-        # On Windows, use event_filter to capture raw virtual key codes
-        # before pynput translates them (pynput loses vk when it converts to char)
-        # and to suppress activation-combo keys from reaching other applications.
+        # On Windows, attach a low-level event filter (via pynput's
+        # win32_event_filter option) to capture raw virtual key codes and
+        # suppress activation-combo keys from reaching other applications.
         if sys.platform == 'win32':
             listener_kwargs['win32_event_filter'] = self._win32_event_filter
 
@@ -810,12 +815,32 @@ class PynputBackend(InputBackend):
             self.mouse_listener.stop()
             self.mouse_listener = None
 
-    def _win32_event_filter(self, msg, data):
-        """Intercept raw Win32 keyboard events to capture the virtual key code
-        and suppress activation-combo keys from reaching other applications.
+    _MODIFIER_VKS = {
+        0xA0, 0xA1,  # VK_LSHIFT / VK_RSHIFT
+        0xA2, 0xA3,  # VK_LCONTROL / VK_RCONTROL
+        0xA4, 0xA5,  # VK_LMENU / VK_RMENU  (Alt)
+        0x5B, 0x5C,  # VK_LWIN / VK_RWIN
+    }
 
-        Returning False suppresses the event from BOTH the OS and pynput callbacks,
-        so we must manually call on_input_event when suppressing.
+    def _win32_event_filter(self, msg, data):
+        """Intercept raw Win32 keyboard events for two purposes:
+
+        1. Capture the virtual key code (vk) before pynput's ToUnicode() call
+           discards it (pynput creates KeyCode(char=..., vk=None) for character
+           keys, making layout-independent hotkey matching impossible).
+        2. Suppress non-modifier keys that complete the activation combo so they
+           don't produce characters in the focused application.
+
+        Suppression uses pynput's internal SuppressException (pynput 1.7.6,
+        pynput._util.win32.SystemHook).  The exception propagates through
+        pynput's hook chain and causes the Win32 hook callback to return 1,
+        which tells Windows to drop the event.  Since pynput callbacks are also
+        skipped, we manually fire on_input_event before raising.
+
+        This filter is only attached on Windows (sys.platform == 'win32').
+
+        Note: _last_vk and _pressed_vks are accessed exclusively from pynput's
+        listener thread, so no synchronization is needed.
         """
         vk = data.vkCode
         self._last_vk = vk
@@ -825,7 +850,6 @@ class PynputBackend(InputBackend):
         WM_KEYUP = 0x0101
         WM_SYSKEYUP = 0x0105
 
-        # Track currently pressed virtual key codes
         is_down = msg in (WM_KEYDOWN, WM_SYSKEYDOWN)
         is_up = msg in (WM_KEYUP, WM_SYSKEYUP)
 
@@ -834,45 +858,25 @@ class PynputBackend(InputBackend):
         elif is_up:
             self._pressed_vks.discard(vk)
 
-        # Suppress non-modifier keys that complete the activation combo
+        # Suppress non-modifier key-down that completes the activation combo
         if (is_down
                 and self._key_chord is not None
-                and self._vk_map is not None):
-            MODIFIER_VKS = {
-                0xA0, 0xA1,  # Shift L/R
-                0xA2, 0xA3,  # Ctrl L/R
-                0xA4, 0xA5,  # Alt L/R
-                0x5B, 0x5C,  # Win L/R
+                and self._vk_map is not None
+                and vk not in self._MODIFIER_VKS):
+            # Translate all currently pressed vks to KeyCodes
+            test_pressed = {
+                kc for pvk in self._pressed_vks
+                if (kc := self._vk_map.get(pvk)) is not None
             }
-            if vk not in MODIFIER_VKS:
-                test_pressed = set()
-                for pressed_vk in self._pressed_vks:
-                    kc = self._vk_map.get(pressed_vk)
-                    if kc:
-                        test_pressed.add(kc)
+            if test_pressed and self._key_chord.would_activate(test_pressed):
+                key_code = self._vk_map.get(vk)
+                if key_code:
+                    self.on_input_event((key_code, InputEvent.KEY_PRESS))
+                # pynput treats SuppressException as handled — listener keeps running
+                from pynput._util.win32 import SystemHook
+                raise SystemHook.SuppressException()
 
-                would_activate = bool(test_pressed)
-                for chord_key in self._key_chord.keys:
-                    if isinstance(chord_key, frozenset):
-                        if not any(k in test_pressed for k in chord_key):
-                            would_activate = False
-                            break
-                    elif chord_key not in test_pressed:
-                        would_activate = False
-                        break
-
-                if would_activate:
-                    # Manually fire on_input_event before suppressing,
-                    # because SuppressException prevents pynput callbacks
-                    key_code = self._vk_map.get(vk)
-                    if key_code:
-                        self.on_input_event((key_code, InputEvent.KEY_PRESS))
-                    # Raise SuppressException to suppress from OS
-                    # (pynput treats this as a handled exception — listener keeps running)
-                    from pynput._util.win32 import SystemHook
-                    raise SystemHook.SuppressException()
-
-        # Handle key-up for keys that are part of the activation chord
+        # Forward key-up for keys tracked by the activation chord
         if (is_up
                 and self._key_chord is not None
                 and self._vk_map is not None):

--- a/src/key_listener.py
+++ b/src/key_listener.py
@@ -275,6 +275,16 @@ class KeyChord:
                 return False
         return True
 
+    def contains_key(self, key: KeyCode) -> bool:
+        """Check if a key is part of this chord's definition."""
+        for k in self.keys:
+            if isinstance(k, frozenset):
+                if key in k:
+                    return True
+            elif k == key:
+                return True
+        return False
+
 class KeyListener:
     """
     Manages input backends and listens for specific key combinations.
@@ -822,6 +832,11 @@ class PynputBackend(InputBackend):
         0x5B, 0x5C,  # VK_LWIN / VK_RWIN
     }
 
+    _WM_KEYDOWN = 0x0100
+    _WM_KEYUP = 0x0101
+    _WM_SYSKEYDOWN = 0x0104
+    _WM_SYSKEYUP = 0x0105
+
     def _win32_event_filter(self, msg, data):
         """Intercept raw Win32 keyboard events for two purposes:
 
@@ -845,13 +860,8 @@ class PynputBackend(InputBackend):
         vk = data.vkCode
         self._last_vk = vk
 
-        WM_KEYDOWN = 0x0100
-        WM_SYSKEYDOWN = 0x0104
-        WM_KEYUP = 0x0101
-        WM_SYSKEYUP = 0x0105
-
-        is_down = msg in (WM_KEYDOWN, WM_SYSKEYDOWN)
-        is_up = msg in (WM_KEYUP, WM_SYSKEYUP)
+        is_down = msg in (self._WM_KEYDOWN, self._WM_SYSKEYDOWN)
+        is_up = msg in (self._WM_KEYUP, self._WM_SYSKEYUP)
 
         if is_down:
             self._pressed_vks.add(vk)
@@ -864,24 +874,28 @@ class PynputBackend(InputBackend):
                 and self._vk_map is not None
                 and vk not in self._MODIFIER_VKS):
             # Translate all currently pressed vks to KeyCodes
-            test_pressed = {
-                kc for pvk in self._pressed_vks
-                if (kc := self._vk_map.get(pvk)) is not None
-            }
+            test_pressed = set()
+            for pvk in self._pressed_vks:
+                kc = self._vk_map.get(pvk)
+                if kc is not None:
+                    test_pressed.add(kc)
             if test_pressed and self._key_chord.would_activate(test_pressed):
                 key_code = self._vk_map.get(vk)
                 if key_code:
                     self.on_input_event((key_code, InputEvent.KEY_PRESS))
                 # pynput treats SuppressException as handled — listener keeps running
-                from pynput._util.win32 import SystemHook
-                raise SystemHook.SuppressException()
+                try:
+                    from pynput._util.win32 import SystemHook
+                    raise SystemHook.SuppressException()
+                except ImportError:
+                    pass
 
-        # Forward key-up for keys tracked by the activation chord
+        # Forward key-up for chord-constituent keys
         if (is_up
                 and self._key_chord is not None
                 and self._vk_map is not None):
             key_code = self._vk_map.get(vk)
-            if key_code and key_code in self._key_chord.pressed_keys:
+            if key_code and self._key_chord.contains_key(key_code):
                 self.on_input_event((key_code, InputEvent.KEY_RELEASE))
 
         return True


### PR DESCRIPTION
This PR fixes three related issues that make WhisperWriter unusable on Windows when a non-Latin keyboard layout (e.g., Russian, Greek, Arabic) is active. All changes are Windows-specific and guarded by `sys.platform == 'win32'`, so Linux and macOS behavior is completely unaffected.

## Problems

### 1. Hotkeys don't work with non-Latin layouts

When the user has a Russian layout active and presses `Alt+F`, pynput's internal `ToUnicode()` call translates the physical F key to the Russian character `а` and creates `KeyCode(char='а', vk=None)`. Since `key_map` only has entries for Latin characters, the lookup fails and `_translate_key_event` was falling back to `KeyCode.SPACE` — causing both missed activations and false triggers.

### 2. Phantom characters appear when pressing hotkeys

Even after fixing detection, pressing `Alt+F` on a Russian layout would type `а` into the focused application, because pynput's default behavior forwards the key event to the OS after processing it.

### 3. Transcribed text is garbled with non-Latin layouts

When using pynput's character-by-character typing (`keyboard.press('ж')`), pynput internally calls `VkKeyScan()` which may fail or produce wrong results for non-Latin characters depending on the active layout. The result is garbled output (e.g., comma becomes `b`).

## Solutions

### Fix 1: Virtual Key code fallback map (`_build_vk_map`)

Added an explicit mapping from Windows Virtual Key codes (which are layout-independent — `VK_F = 0x46` regardless of layout) to our internal `KeyCode` enum. When pynput's standard `key_map` lookup fails, we fall back to VK codes captured from the raw Win32 event.

### Fix 2: `win32_event_filter` with `SuppressException`

Added a low-level event filter via pynput's `win32_event_filter` listener option. This filter:
- Captures the raw VK code **before** pynput's `ToUnicode()` discards it
- Detects when a key-down event completes the activation combo
- Manually fires `on_input_event` so the chord is properly tracked
- Raises `pynput._util.win32.SystemHook.SuppressException` to prevent the key from reaching other applications (the Win32 hook returns 1, telling Windows to drop the event)

Only non-modifier keys are suppressed — modifier keys (Alt, Ctrl, Shift, Win) pass through normally so they don't break other shortcuts.

### Fix 3: Clipboard paste input method

Added a new `clipboard` option for the `input_method` setting that:
- Sets clipboard content via Win32 API (`GlobalAlloc` / `SetClipboardData` with `CF_UNICODETEXT`)
- Simulates `Ctrl+V` via `keybd_event` using virtual key codes (layout-independent)
- Preserves and restores the user's previous clipboard content
- Works instantly (no per-character delay), handles any Unicode text, and is completely layout-independent

The implementation uses `ctypes` directly — no external dependencies. On non-Windows platforms it falls back to pynput. The default `input_method` remains `pynput` for cross-platform compatibility.

### Bonus fix: `KeyCode.SPACE` default removed

`_translate_key_event` was using `self.key_map.get(pynput_key, KeyCode.SPACE)` — any unrecognized key was silently mapped to SPACE, causing false chord activations. Now unrecognized keys return `None` and are ignored.

## Files changed

- **`src/key_listener.py`** — VK map, event filter, `would_activate()`, `contains_key()`, None handling
- **`src/input_simulation.py`** — clipboard paste method via Win32 API
- **`src/config_schema.yaml`** — added `clipboard` to `input_method` options with description

## Testing

Tested manually on Windows 11 with Russian and English layouts:
- [x] Hotkey activation works with English layout
- [x] Hotkey activation works with Russian layout (no phantom characters)
- [x] Transcribed text inserted correctly via clipboard paste (English)
- [x] Transcribed text inserted correctly via clipboard paste (Russian)
- [x] Original clipboard content is preserved after paste
- [x] Application starts without errors
- [ ] Verify no regressions on Linux (evdev backend — Windows code not activated)
- [ ] Verify no regressions on macOS (pynput backend — Windows code not activated)

## Notes

- The `SuppressException` import uses pynput's internal API (`pynput._util.win32.SystemHook`), wrapped in `try/except ImportError` for resilience against future pynput versions. Tested with pynput 1.7.6.
- Related to #75 which also fixes the `KeyCode.SPACE` default, but this PR goes further by solving the root cause (layout-independent key detection) and adding the clipboard paste method.