### PR TITLE
Add re-paste last transcription hotkey

### DIFF
--- a/src/config_schema.yaml
+++ b/src/config_schema.yaml
@@ -90,6 +90,10 @@ recording_options:
     value: ctrl+shift+space
     type: str
     description: "The keyboard shortcut to activate the recording and transcribing process. Separate keys with a '+'."
+  repaste_key:
+    value: ctrl+shift+v
+    type: str
+    description: "The keyboard shortcut to re-insert the last transcribed text. Useful when text didn't paste correctly or you switched windows. Separate keys with a '+'. Leave empty to disable."
   input_backend:
     value: auto
     type: str

--- a/src/input_simulation.py
+++ b/src/input_simulation.py
@@ -2,7 +2,7 @@ import subprocess
 import os
 import signal
 import time
-from pynput.keyboard import Controller as PynputController
+from pynput.keyboard import Controller as PynputController, Key as PynputKey
 
 from utils import ConfigManager
 
@@ -50,6 +50,18 @@ class InputSimulator:
         if self.dotool_process:
             os.kill(self.dotool_process.pid, signal.SIGINT)
             self.dotool_process = None
+
+    def release_held_modifiers(self):
+        """Release any physically held modifier keys to prevent interference with typing."""
+        if hasattr(self, 'keyboard') and self.keyboard:
+            for mod_key in (PynputKey.ctrl_l, PynputKey.ctrl_r,
+                            PynputKey.shift_l, PynputKey.shift_r,
+                            PynputKey.alt_l, PynputKey.alt_r,
+                            PynputKey.cmd_l, PynputKey.cmd_r):
+                try:
+                    self.keyboard.release(mod_key)
+                except Exception:
+                    pass
 
     def typewrite(self, text):
         """

--- a/src/key_listener.py
+++ b/src/key_listener.py
@@ -280,12 +280,9 @@ class KeyListener:
         """Initialize the KeyListener with backends and activation keys."""
         self.backends = []
         self.active_backend = None
-        self.key_chord = None
-        self.callbacks = {
-            "on_activate": [],
-            "on_deactivate": []
-        }
-        self.load_activation_keys()
+        self.key_chords: dict[str, KeyChord] = {}
+        self.callbacks: dict[str, dict[str, list]] = {}
+        self.load_key_chords()
         self.initialize_backends()
         self.select_backend_from_config()
 
@@ -351,11 +348,22 @@ class KeyListener:
         if self.active_backend:
             self.active_backend.stop()
 
-    def load_activation_keys(self):
-        """Load activation keys from configuration."""
-        key_combination = ConfigManager.get_config_value('recording_options', 'activation_key')
-        keys = self.parse_key_combination(key_combination)
-        self.set_activation_keys(keys)
+    def load_key_chords(self):
+        """Load all key chords from configuration."""
+        activation_key = ConfigManager.get_config_value('recording_options', 'activation_key')
+        keys = self.parse_key_combination(activation_key)
+        self.register_chord("activation", keys)
+
+        repaste_key = ConfigManager.get_config_value('recording_options', 'repaste_key')
+        if repaste_key:
+            keys = self.parse_key_combination(repaste_key)
+            self.register_chord("repaste", keys)
+
+    def register_chord(self, name: str, keys: Set[KeyCode | frozenset[KeyCode]]):
+        """Register a named key chord."""
+        self.key_chords[name] = KeyChord(keys)
+        if name not in self.callbacks:
+            self.callbacks[name] = {"on_activate": [], "on_deactivate": []}
 
     def parse_key_combination(self, combination_string: str) -> Set[KeyCode | frozenset[KeyCode]]:
         """Parse a string representation of key combination into a set of KeyCodes."""
@@ -381,36 +389,39 @@ class KeyListener:
 
     def set_activation_keys(self, keys: Set[KeyCode]):
         """Set the activation keys for the KeyChord."""
-        self.key_chord = KeyChord(keys)
+        self.register_chord("activation", keys)
 
     def on_input_event(self, event):
-        """Handle input events and trigger callbacks if the key chord becomes active or inactive."""
-        if not self.key_chord or not self.active_backend:
+        """Handle input events and trigger callbacks if any key chord becomes active or inactive."""
+        if not self.key_chords or not self.active_backend:
             return
 
         key, event_type = event
 
-        was_active = self.key_chord.is_active()
-        is_active = self.key_chord.update(key, event_type)
+        for chord_name, chord in self.key_chords.items():
+            was_active = chord.is_active()
+            is_active = chord.update(key, event_type)
 
-        if not was_active and is_active:
-            self._trigger_callbacks("on_activate")
-        elif was_active and not is_active:
-            self._trigger_callbacks("on_deactivate")
+            if not was_active and is_active:
+                self._trigger_callbacks(chord_name, "on_activate")
+            elif was_active and not is_active:
+                self._trigger_callbacks(chord_name, "on_deactivate")
 
-    def add_callback(self, event: str, callback: Callable):
-        """Add a callback function for a specific event."""
-        if event in self.callbacks:
-            self.callbacks[event].append(callback)
+    def add_callback(self, chord_name: str, event: str, callback: Callable):
+        """Add a callback function for a specific chord and event."""
+        if chord_name not in self.callbacks:
+            self.callbacks[chord_name] = {"on_activate": [], "on_deactivate": []}
+        if event in self.callbacks[chord_name]:
+            self.callbacks[chord_name][event].append(callback)
 
-    def _trigger_callbacks(self, event: str):
-        """Trigger all callbacks associated with a specific event."""
-        for callback in self.callbacks.get(event, []):
+    def _trigger_callbacks(self, chord_name: str, event: str):
+        """Trigger all callbacks associated with a specific chord and event."""
+        for callback in self.callbacks.get(chord_name, {}).get(event, []):
             callback()
 
     def update_activation_keys(self):
-        """Update activation keys from the current configuration."""
-        self.load_activation_keys()
+        """Update all key chords from the current configuration."""
+        self.load_key_chords()
 
 class EvdevBackend(InputBackend):
     """

--- a/src/key_listener.py
+++ b/src/key_listener.py
@@ -350,6 +350,9 @@ class KeyListener:
 
     def load_key_chords(self):
         """Load all key chords from configuration."""
+        # Clear stale chords (e.g. repaste disabled) while preserving callbacks
+        self.key_chords.clear()
+
         activation_key = ConfigManager.get_config_value('recording_options', 'activation_key')
         keys = self.parse_key_combination(activation_key)
         self.register_chord("activation", keys)

--- a/src/main.py
+++ b/src/main.py
@@ -188,6 +188,7 @@ class WhisperWriterApp(QObject):
             return
         if self.last_transcription:
             self.input_simulator.release_held_modifiers()
+            time.sleep(0.05)
             self.input_simulator.typewrite(self.last_transcription)
 
     def run(self):

--- a/src/main.py
+++ b/src/main.py
@@ -43,10 +43,12 @@ class WhisperWriterApp(QObject):
         Initialize the components of the application.
         """
         self.input_simulator = InputSimulator()
+        self.last_transcription = None
 
         self.key_listener = KeyListener()
-        self.key_listener.add_callback("on_activate", self.on_activation)
-        self.key_listener.add_callback("on_deactivate", self.on_deactivation)
+        self.key_listener.add_callback("activation", "on_activate", self.on_activation)
+        self.key_listener.add_callback("activation", "on_deactivate", self.on_deactivation)
+        self.key_listener.add_callback("repaste", "on_activate", self.on_repaste)
 
         model_options = ConfigManager.get_config_section('model_options')
         model_path = model_options.get('local', {}).get('model_path')
@@ -166,6 +168,8 @@ class WhisperWriterApp(QObject):
         """
         When the transcription is complete, type the result and start listening for the activation key again.
         """
+        if result:
+            self.last_transcription = result
         self.input_simulator.typewrite(result)
 
         if ConfigManager.get_config_value('misc', 'noise_on_completion'):
@@ -175,6 +179,16 @@ class WhisperWriterApp(QObject):
             self.start_result_thread()
         else:
             self.key_listener.start()
+
+    def on_repaste(self):
+        """
+        Re-insert the last transcribed text.
+        """
+        if self.result_thread and self.result_thread.isRunning():
+            return
+        if self.last_transcription:
+            self.input_simulator.release_held_modifiers()
+            self.input_simulator.typewrite(self.last_transcription)
 
     def run(self):
         """


### PR DESCRIPTION
## Summary

When transcribed text doesn't paste correctly — the user may have switched windows, the target app may not have been focused, or clipboard paste may have failed — there's currently no way to re-insert the last transcription without recording again.

This adds a configurable `repaste_key` hotkey (default: `ctrl+shift+v`) that re-inserts the last transcribed text on demand.

- **New config option** `repaste_key` in `recording_options` — auto-appears in settings UI
- **Refactored** `KeyListener` from single chord to named chords dict, enabling multiple independent hotkeys
- **Stores** last transcription result for re-use
- **Releases** held modifier keys before typing to prevent interference (e.g. Ctrl+Shift still held when callback fires)
- Repaste is ignored while recording/transcribing is in progress
- Leave `repaste_key` empty in settings to disable

> **Note:** The default `ctrl+shift+v` may conflict with "paste without formatting" in some applications. Users can change the hotkey in settings to avoid conflicts.

## Files changed

| File | Change |
|---|---|
| `src/config_schema.yaml` | Add `repaste_key` option |
| `src/key_listener.py` | Refactor single chord → named chords dict |
| `src/input_simulation.py` | Add `release_held_modifiers()` |
| `src/main.py` | Store last transcription, add `on_repaste()`, update callback API |

## Test plan

- [ ] Activation hotkey still works (record + transcribe)
- [ ] Press `ctrl+shift+v` after transcription — last text re-inserted
- [ ] Press repaste key with no prior transcription — silently does nothing
- [ ] Press repaste key while recording — ignored
- [ ] Settings UI shows the new `repaste_key` field
- [ ] Change repaste key in settings, restart, verify new key works
- [ ] Leave repaste key empty — feature disabled, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)