### PR TITLE
Stop existing listeners in PynputBackend.start() to fix X11 connection leak

### DIFF
--- a/src/key_listener.py
+++ b/src/key_listener.py
@@ -763,6 +763,7 @@ class PynputBackend(InputBackend):
 
     def start(self):
         """Start listening for keyboard and mouse events."""
+        self.stop()
         if self.keyboard is None or self.mouse is None:
             from pynput import keyboard, mouse
             self.keyboard = keyboard


### PR DESCRIPTION
PynputBackend.start() created new keyboard and mouse listeners without stopping existing ones. on_transcription_complete() calls start() after every dictation, so each dictation orphaned two running listeners, each holding open X11 connections that were never closed.

Over time this exhausts the X server's client connection limit (256), after which no new application can open a window ("Maximum number of clients reached").

Calling self.stop() at the top of start() releases the existing listeners before creating new ones. stop() is already null-safe, so the initial start() is unaffected.

Measured on Linux Mint Cinnamon (X11), hold-to-record mode:
- Before: 11 connections at startup, +4 per dictation (11 -> 31 over 5)
- After:  7 connections at startup, flat (7 -> 7 over 5)