### PR TITLE
🐛 Fix config file corruption from UTF-8 BOM

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -75,7 +75,7 @@ class ConfigManager:
             base_dir = os.path.dirname(os.path.abspath(__file__))
             schema_path = os.path.join(base_dir, 'config_schema.yaml')
 
-        with open(schema_path, 'r') as file:
+        with open(schema_path, 'r', encoding='utf-8-sig') as file:
             schema = yaml.safe_load(file)
         return schema
 
@@ -105,7 +105,7 @@ class ConfigManager:
 
         if config_path and os.path.isfile(config_path):
             try:
-                with open(config_path, 'r') as file:
+                with open(config_path, 'r', encoding='utf-8-sig') as file:
                     user_config = yaml.safe_load(file)
                     deep_update(self.config, user_config)
             except yaml.YAMLError:
@@ -116,7 +116,7 @@ class ConfigManager:
         """Save the current configuration to a YAML file."""
         if cls._instance is None:
             raise RuntimeError("ConfigManager not initialized")
-        with open(config_path, 'w') as file:
+        with open(config_path, 'w', encoding='utf-8') as file:
             yaml.dump(cls._instance.config, file, default_flow_style=False)
 
     @classmethod


### PR DESCRIPTION
## Summary

- **Fix: Config file corruption from UTF-8 BOM** — ConfigManager used plain open() without specifying an encoding. When config.yaml had a UTF-8 BOM (added by some Windows editors, Notepad, or PowerShell's Set-Content -Encoding UTF8), the BOM bytes were prepended to the first YAML key (e.g. \ufeffmisc instead of misc). This caused the key to be misread, creating a duplicate section on the next save_config() call and silently losing user overrides under the corrupted key.

### Root cause
open(path, 'r') on Windows uses the system default encoding, which does not strip a UTF-8 BOM. The BOM becomes part of the first line's content, making the first YAML key unrecognizable.

### Fix
- **Read** with encoding='utf-8-sig' — strips the BOM if present, no-op if absent
- **Write** with encoding='utf-8' — never adds a BOM

Applied to all three file operations in utils.py:
- load_config_schema (reads config_schema.yaml)
- load_user_config (reads config.yaml)
- save_config (writes config.yaml)

### Files changed
- src/utils.py — 3 lines changed (add encoding= to each open() call)

#### Test plan
- [ ] Create a config.yaml with a UTF-8 BOM prefix, run the app — config should load correctly (no duplicate keys)
- [ ] Save config via the Settings GUI — written file should not have a BOM
- [ ] Verify normal (no BOM) config files still load correctly

Generated with [Devin](https://devin.ai)